### PR TITLE
Create a constructor for roll with origin

### DIFF
--- a/src/main/java/me/jordin/deltoid/tacnode/parsers/RotationParser.java
+++ b/src/main/java/me/jordin/deltoid/tacnode/parsers/RotationParser.java
@@ -27,6 +27,11 @@ public class RotationParser implements ArgumentParser<Rotation> {
         this(relativeTo, false);
     }
 
+    
+    public RotationParser(boolean includeRoll) {
+        this(ORIGIN, includeRoll);
+    }
+    
     public RotationParser(Supplier<Rotation> relativeTo, boolean includeRoll) {
         this.relativeTo = relativeTo;
         this.includeRoll = includeRoll;


### PR DESCRIPTION
This means that parsers which take roll for an absolute angle do not need to explicitly state ORIGIN when constructing